### PR TITLE
Adding Linux build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,33 +2,35 @@ cmake_minimum_required(VERSION 3.3)
 
 project(ShooterDemo)
 
-if(NOT EXISTS ${PROJECT_BINARY_DIR}/lib/assimp.lib)
-	# Unpack libraries
-	execute_process(
-		COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_BINARY_DIR}/lib/DemoShooter_win7_x32_lib.tar.gz
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-	)
-endif()
+# if we are compiling on windows, default to using local contrib include files and libraries
+# otherwise, on linux, mac, search for global libraries since there might be version mismatch 
+# between local include files, and system libraries
+IF(WIN32)
+	option(LocalIncludes "Use local includes" ON)
+ELSE(WIN32)
+	option(LocalIncludes "Use local includes" OFF)
+ENDIF(WIN32)
 
-if (NOT EXISTS ${PROJECT_BINARY_DIR}/bin/res)
-	# Unpack binaries
-	execute_process(
-		COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_BINARY_DIR}/bin/ShooterDemo_win7_x32_bin.tar.gz
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-	)
-endif()
+# allow GCC to build with C++14
+# need -fpermissive to forgive a few const errors
+IF(CMAKE_COMPILER_IS_GNUCXX)
+   set(CMAKE_CXX_FLAGS "-Wall -fpermissive -std=c++14 -ggdb ${CMAKE_CXX_FLAGS}")
+   set(FILESYSTEM_LIB stdc++fs)
+ENDIF()
+
+# extra CMAKE modules
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+
+# Setting up build structure
 
 set(CMAKE_PREFIX_PATH ${PROJECT_SOURCE_DIR})
-
-# CMAKE extensions
-set(CMAKE_MODULE_PATH cmake_modules)
 
 SET(OUTPUT_BINDIR ${PROJECT_BINARY_DIR}/bin)
 MAKE_DIRECTORY(${OUTPUT_BINDIR})
 
 SET(OUTPUT_LIBDIR ${PROJECT_BINARY_DIR}/lib)
 MAKE_DIRECTORY(${OUTPUT_LIBDIR})
-
 
 SET (CMAKE_ARCHIVE_OUTPUT_DIRECTORY  ${OUTPUT_LIBDIR} CACHE PATH "build directory")
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY  ${OUTPUT_BINDIR} CACHE PATH "build directory")
@@ -50,6 +52,39 @@ ELSE()
   SET("CMAKE_LIBRARY_OUTPUT_DIRECTORY_${CONF}" "${OUTPUT_LIBDIR}")
 ENDIF()
 ENDFOREACH()
+
+# Unpacking Resources:
+# Windows build comes with included development libraries
+IF(WIN32)
+	IF(NOT EXISTS ${PROJECT_BINARY_DIR}/lib/assimp.lib)
+		# Unpack libraries
+		execute_process(
+			COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_SOURCE_DIR}/lib/DemoShooter_win7_x32_lib.tar.gz
+			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+		)
+	ENDIF()
+	IF(NOT EXISTS ${PROJECT_BINARY_DIR}/bin/res)
+		execute_process(
+			COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_SOURCE_DIR}/bin/ShooterDemo_win7_x32_bin.tar.gz
+			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+		)
+	ENDIF()
+ENDIF(WIN32)
+
+#Linux build needs system development libraries, so we only need to extract the res folder
+IF(UNIX)
+	IF(NOT EXISTS ${PROJECT_BINARY_DIR}/bin/res)
+		# Unpack resources only, don't need the windows libs
+		execute_process(
+			COMMAND tar -xzvf ${PROJECT_SOURCE_DIR}/bin/ShooterDemo_win7_x32_bin.tar.gz res/
+			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+		)
+	ENDIF()
+ENDIF(UNIX)
+
+
+
+# Set up project structure
 
 set(CONTRIB_PREFIX contrib)
 
@@ -94,18 +129,36 @@ find_package(OpenGL REQUIRED)
 include_directories(include)
 include_directories(bin/res/shaders)
 include_directories(${CONTRIB_PREFIX})
-include_directories(${CONTRIB_PREFIX}/GL)
-include_directories(${CONTRIB_PREFIX}/glm)
-include_directories(${CONTRIB_PREFIX}/SDL2)
-include_directories(${CONTRIB_PREFIX}/assimp)
 include_directories(${CONTRIB_PREFIX}/minizip)
-include_directories(${OPENGL_INCLUDE_DIR})
+
 include_directories(${Recast_INCLUDE_DIR})
 include_directories(${Detour_INCLUDE_DIR})
 include_directories(${DetourTileCache_INCLUDE_DIR})
 include_directories(${DetourCrowd_INCLUDE_DIR})
 include_directories(${DebugUtils_INCLUDE_DIR})
 include_directories(${nanovg_INCLUDE_DIR})
+
+IF(LocalIncludes)
+	include_directories(${CONTRIB_PREFIX}/SDL2)
+	include_directories(${CONTRIB_PREFIX}/assimp)
+	include_directories(${CONTRIB_PREFIX}/GL)
+	include_directories(${CONTRIB_PREFIX}/glm)
+ELSE(LocalIncludes)
+	find_package(SDL2 		REQUIRED)
+	find_package(SDL2_image REQUIRED)
+	find_package(SDL2_ttf 	REQUIRED)
+	find_package(assimp 	REQUIRED)
+	find_package(ZLIB 		REQUIRED)
+	find_package(GLEW 		REQUIRED)
+	find_package(glm 		REQUIRED)
+	include_directories(${OPENGL_INCLUDE_DIR})
+	include_directories(${SDL2_INCLUDE_DIR})
+	include_directories(${assimp_INCLUDE_DIRS})
+	include_directories(${ZLIB_INCLUDE_DIRS})
+	include_directories(${GLEW_INCLUDE_DIRS})
+	include_directories(${GLM_INCLUDE_DIRS})
+ENDIF(LocalIncludes)
+
 
 # Project headers
 file(GLOB HEADER_FILES1 include/*.h)
@@ -131,12 +184,24 @@ add_executable(
   $<TARGET_OBJECTS:minizip>
   $<TARGET_OBJECTS:nanovg>)
 
-TARGET_LINK_LIBRARIES(${PROJECT_NAME} 
-  lib/SDL2
-  lib/SDL2main
-  lib/SDL2_image
-  lib/SDL2_ttf
-  lib/assimp
-  lib/zdll
-  lib/glew32
-  ${OPENGL_LIBRARIES})
+IF(WIN32)
+	TARGET_LINK_LIBRARIES(${PROJECT_NAME} 
+		lib/SDL2
+  		lib/SDL2main
+  		lib/SDL2_image
+  		lib/SDL2_ttf
+  		lib/assimp
+  		lib/zdll
+  		lib/glew32
+  		${OPENGL_LIBRARIES})
+ELSE(WIN32)
+	TARGET_LINK_LIBRARIES(${PROJECT_NAME} 
+		${SDL2_LIBRARY}
+	  	${SDL2_IMAGE_LIBRARY}
+	  	${SDL2_TTF_LIBRARY}
+	  	${assimp_LIBRARIES}
+	  	${ZLIB_LIBRARY}
+	  	${OPENGL_LIBRARIES}
+		${GLEW_LIBRARIES}
+        ${FILESYSTEM_LIB})
+ENDIF(WIN32)

--- a/cmake/FindPkgMacros.cmake
+++ b/cmake/FindPkgMacros.cmake
@@ -1,0 +1,143 @@
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+
+##################################################################
+# Provides some common functionality for the FindPackage modules
+##################################################################
+
+# Begin processing of package
+macro(findpkg_begin PREFIX)
+  if (NOT ${PREFIX}_FIND_QUIETLY)
+    message(STATUS "Looking for ${PREFIX}...")
+  endif ()
+endmacro(findpkg_begin)
+
+# Display a status message unless FIND_QUIETLY is set
+macro(pkg_message PREFIX)
+  if (NOT ${PREFIX}_FIND_QUIETLY)
+    message(STATUS ${ARGN})
+  endif ()
+endmacro(pkg_message)
+
+# Get environment variable, define it as ENV_$var and make sure backslashes are converted to forward slashes
+macro(getenv_path VAR)
+   set(ENV_${VAR} $ENV{${VAR}})
+   # replace won't work if var is blank
+   if (ENV_${VAR})
+     string( REGEX REPLACE "\\\\" "/" ENV_${VAR} ${ENV_${VAR}} )
+   endif ()
+endmacro(getenv_path)
+
+# Construct search paths for includes and libraries from a PREFIX_PATH
+macro(create_search_paths PREFIX)
+  foreach(dir ${${PREFIX}_PREFIX_PATH})
+    set(${PREFIX}_INC_SEARCH_PATH ${${PREFIX}_INC_SEARCH_PATH}
+      ${dir}/include ${dir}/include/${PREFIX} ${dir}/Headers)
+    set(${PREFIX}_LIB_SEARCH_PATH ${${PREFIX}_LIB_SEARCH_PATH}
+      ${dir}/lib ${dir}/lib/${PREFIX} ${dir}/Libs)
+  endforeach(dir)
+  set(${PREFIX}_FRAMEWORK_SEARCH_PATH ${${PREFIX}_PREFIX_PATH})
+endmacro(create_search_paths)
+
+# clear cache variables if a certain variable changed
+macro(clear_if_changed TESTVAR)
+  # test against internal check variable
+  if (NOT "${${TESTVAR}}" STREQUAL "${${TESTVAR}_INT_CHECK}")
+    message(STATUS "${TESTVAR} changed.")
+    foreach(var ${ARGN})
+      set(${var} "NOTFOUND" CACHE STRING "x" FORCE)
+    endforeach(var)
+  endif ()
+  set(${TESTVAR}_INT_CHECK ${${TESTVAR}} CACHE INTERNAL "x" FORCE)
+endmacro(clear_if_changed)
+
+# Try to get some hints from pkg-config, if available
+macro(use_pkgconfig PREFIX PKGNAME)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(${PREFIX} ${PKGNAME})
+  endif ()
+endmacro (use_pkgconfig)
+
+# Couple a set of release AND debug libraries (or frameworks)
+macro(make_library_set PREFIX)
+  if (${PREFIX}_FWK)
+    set(${PREFIX} ${${PREFIX}_FWK})
+  elseif (${PREFIX}_REL AND ${PREFIX}_DBG)
+    set(${PREFIX} optimized ${${PREFIX}_REL} debug ${${PREFIX}_DBG})
+  elseif (${PREFIX}_REL)
+    set(${PREFIX} ${${PREFIX}_REL})
+  elseif (${PREFIX}_DBG)
+    set(${PREFIX} ${${PREFIX}_DBG})
+  endif ()
+endmacro(make_library_set)
+
+# Generate debug names from given release names
+macro(get_debug_names PREFIX)
+  foreach(i ${${PREFIX}})
+    set(${PREFIX}_DBG ${${PREFIX}_DBG} ${i}d ${i}D ${i}_d ${i}_D ${i}_debug ${i})
+  endforeach(i)
+endmacro(get_debug_names)
+
+# Add the parent dir from DIR to VAR
+macro(add_parent_dir VAR DIR)
+  get_filename_component(${DIR}_TEMP "${${DIR}}/.." ABSOLUTE)
+  set(${VAR} ${${VAR}} ${${DIR}_TEMP})
+endmacro(add_parent_dir)
+
+# Do the final processing for the package find.
+macro(findpkg_finish PREFIX)
+  # skip if already processed during this run
+  if (NOT ${PREFIX}_FOUND)
+    if (${PREFIX}_INCLUDE_DIR AND ${PREFIX}_LIBRARY)
+      set(${PREFIX}_FOUND TRUE)
+      set(${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIR})
+      set(${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARY})
+      if (NOT ${PREFIX}_FIND_QUIETLY)
+        message(STATUS "Found ${PREFIX}: ${${PREFIX}_LIBRARIES}")
+      endif ()
+    else ()
+      if (NOT ${PREFIX}_FIND_QUIETLY)
+        message(STATUS "Could not locate ${PREFIX}")
+      endif ()
+      if (${PREFIX}_FIND_REQUIRED)
+        message(FATAL_ERROR "Required library ${PREFIX} not found! Install the library (including dev packages) and try again. If the library is already installed, set the missing variables manually in cmake.")
+      endif ()
+    endif ()
+
+    mark_as_advanced(${PREFIX}_INCLUDE_DIR ${PREFIX}_LIBRARY ${PREFIX}_LIBRARY_REL ${PREFIX}_LIBRARY_DBG ${PREFIX}_LIBRARY_FWK)
+  endif ()
+endmacro(findpkg_finish)
+
+
+# Slightly customised framework finder
+MACRO(findpkg_framework fwk)
+  IF(APPLE)
+    SET(${fwk}_FRAMEWORK_PATH
+      ${${fwk}_FRAMEWORK_SEARCH_PATH}
+      ${CMAKE_FRAMEWORK_PATH}
+      ~/Library/Frameworks
+      /Library/Frameworks
+      /System/Library/Frameworks
+      /Network/Library/Frameworks
+      /Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS3.0.sdk/System/Library/Frameworks/
+      /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS3.0.sdk/System/Library/Frameworks/
+    )
+    FOREACH(dir ${${fwk}_FRAMEWORK_PATH})
+      SET(fwkpath ${dir}/${fwk}.framework)
+      IF(EXISTS ${fwkpath})
+        SET(${fwk}_FRAMEWORK_INCLUDES ${${fwk}_FRAMEWORK_INCLUDES}
+          ${fwkpath}/Headers ${fwkpath}/PrivateHeaders)
+        if (NOT ${fwk}_LIBRARY_FWK)
+          SET(${fwk}_LIBRARY_FWK "-framework ${fwk}")
+        endif ()
+      ENDIF(EXISTS ${fwkpath})
+    ENDFOREACH(dir)
+  ENDIF(APPLE)
+ENDMACRO(findpkg_framework)

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -1,0 +1,163 @@
+# Locate SDL2 library
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES include/SDL2 include
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+FIND_LIBRARY(SDL2_LIBRARY_TEMP
+	NAMES SDL2
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES lib64 lib
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+	IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+		# Non-OS X framework versions expect you to also dynamically link to
+		# SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+		# seem to provide SDL2main for compatibility even though they don't
+		# necessarily need it.
+		FIND_LIBRARY(SDL2MAIN_LIBRARY
+			NAMES SDL2main
+			HINTS
+			$ENV{SDL2DIR}
+			PATH_SUFFIXES lib64 lib
+			PATHS ${SDL2_SEARCH_PATHS}
+		)
+	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+	FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+IF(MINGW)
+	SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+IF(SDL2_LIBRARY_TEMP)
+	# For SDL2main
+	IF(NOT SDL2_BUILDING_LIBRARY)
+		IF(SDL2MAIN_LIBRARY)
+			SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+		ENDIF(SDL2MAIN_LIBRARY)
+	ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+	# For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+	# CMake doesn't display the -framework Cocoa string in the UI even
+	# though it actually is there if I modify a pre-used variable.
+	# I think it has something to do with the CACHE STRING.
+	# So I use a temporary variable until the end so I can set the
+	# "real" variable in one-shot.
+	IF(APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+	ENDIF(APPLE)
+
+	# For threads, as mentioned Apple doesn't need this.
+	# In fact, there seems to be a problem if I used the Threads package
+	# and try using this line, so I'm just skipping it entirely for OS X.
+	IF(NOT APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+	ENDIF(NOT APPLE)
+
+	# For MinGW library
+	IF(MINGW)
+		SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+	ENDIF(MINGW)
+
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+ENDIF(SDL2_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)

--- a/cmake/FindSDL2_image.cmake
+++ b/cmake/FindSDL2_image.cmake
@@ -1,0 +1,158 @@
+# Locate SDL2_image library
+# This module defines
+# SDL2_IMAGE_LIBRARY, the name of the library to link against
+# SDL2_IMAGE_FOUND, if false, do not try to link to SDL2_image
+# SDL2_IMAGE_INCLUDE_DIR, where to find SDL_image.h
+#
+# Additional Note: If you see an empty SDL2_IMAGE_LIBRARY_TEMP in your configuration
+# and no SDL2_IMAGE_LIBRARY, it means CMake did not find your SDL2_Image library
+# (SDL2_image.dll, libsdl2_image.so, SDL2_image.framework, etc).
+# Set SDL2_IMAGE_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_IMAGE_LIBRARY
+# variable, but when these values are unset, SDL2_IMAGE_LIBRARY does not get created.
+#
+# $SDL2 is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2
+# used in building SDL2.
+# l.e.galup 9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL2 guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_IMAGE_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL2 convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+#
+# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
+# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
+# was not created for redistribution, and exists temporarily pending official
+# SDL2 CMake modules.
+# 
+# Note that on windows this will only search for the 32bit libraries, to search
+# for 64bit change x86/i686-w64 to x64/x86_64-w64
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# CMake - Cross Platform Makefile Generator
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+# nor the names of their contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+# License text for the above reference.)
+
+FIND_PATH(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+	HINTS
+	${SDL2}
+	$ENV{SDL2}
+	$ENV{SDL2_IMAGE}
+	PATH_SUFFIXES include/SDL2 include SDL2
+	i686-w64-mingw32/include/SDL2
+	x86_64-w64-mingw32/include/SDL2
+	PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local/include/SDL2
+	/usr/include/SDL2
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+)
+
+# Lookup the 64 bit libs on x64
+IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
+		NAMES SDL2_image
+		HINTS
+		${SDL2}
+		$ENV{SDL2}
+		$ENV{SDL2_IMAGE}
+		PATH_SUFFIXES lib64 lib
+		lib/x64
+		x86_64-w64-mingw32/lib
+		PATHS
+		/sw
+		/opt/local
+		/opt/csw
+		/opt
+	)
+# On 32bit build find the 32bit libs
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	FIND_LIBRARY(SDL2_IMAGE_LIBRARY_TEMP
+		NAMES SDL2_image
+		HINTS
+		${SDL2}
+		$ENV{SDL2}
+		$ENV{SDL2_IMAGE}
+		PATH_SUFFIXES lib
+		lib/x86
+		i686-w64-mingw32/lib
+		PATHS
+		/sw
+		/opt/local
+		/opt/csw
+		/opt
+	)
+ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+SET(SDL2_IMAGE_FOUND "NO")
+	IF(SDL2_IMAGE_LIBRARY_TEMP)
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARY_TEMP} CACHE STRING "Where the SDL2_image Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_IMAGE_LIBRARY_TEMP "${SDL2_IMAGE_LIBRARY_TEMP}" CACHE INTERNAL "")
+	SET(SDL2_IMAGE_FOUND "YES")
+ENDIF(SDL2_IMAGE_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_IMAGE REQUIRED_VARS SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)
+

--- a/cmake/FindSDL2_ttf.cmake
+++ b/cmake/FindSDL2_ttf.cmake
@@ -1,0 +1,157 @@
+# Locate SDL2_ttf library
+# This module defines
+# SDL2_TTF_LIBRARY, the name of the library to link against
+# SDL2_TTF_FOUND, if false, do not try to link to SDL2_ttf
+# SDL2_TTF_INCLUDE_DIR, where to find SDL_image.h
+#
+# Additional Note: If you see an empty SDL2_TTF_LIBRARY_TEMP in your configuration
+# and no SDL2_TTF_LIBRARY, it means CMake did not find your SDL2_Image library
+# (SDL2_ttf.dll, libsdl2_image.so, SDL2_ttf.framework, etc).
+# Set SDL2_TTF_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_TTF_LIBRARY
+# variable, but when these values are unset, SDL2_TTF_LIBRARY does not get created.
+#
+# $SDL2 is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2
+# used in building SDL2.
+# l.e.galup 9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL2 guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_TTF_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL2 convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+#
+# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
+# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
+# was not created for redistribution, and exists temporarily pending official
+# SDL2 CMake modules.
+# 
+# Note that on windows this will only search for the 32bit libraries, to search
+# for 64bit change x86/i686-w64 to x64/x86_64-w64
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# CMake - Cross Platform Makefile Generator
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+# nor the names of their contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+# License text for the above reference.)
+
+FIND_PATH(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+	HINTS
+	${SDL2}
+	$ENV{SDL2}
+	$ENV{SDL2_TTF}
+	PATH_SUFFIXES include/SDL2 include SDL2
+	i686-w64-mingw32/include/SDL2
+	PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local/include/SDL2
+	/usr/include/SDL2
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+)
+
+# Lookup the 64 bit libs on x64
+IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	FIND_LIBRARY(SDL2_TTF_LIBRARY_TEMP
+		NAMES SDL2_ttf
+		HINTS
+		${SDL2}
+		$ENV{SDL2}
+		$ENV{SDL2_TTF}
+		PATH_SUFFIXES lib64 lib
+		lib/x64
+		x86_64-w64-mingw32/lib
+		PATHS
+		/sw
+		/opt/local
+		/opt/csw
+		/opt
+	)
+# On 32bit build find the 32bit libs
+ELSE(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	FIND_LIBRARY(SDL2_TTF_LIBRARY_TEMP
+		NAMES SDL2_ttf
+		HINTS
+		${SDL2}
+		$ENV{SDL2}
+		$ENV{SDL2_TTF}
+		PATH_SUFFIXES lib
+		lib/x86
+		i686-w64-mingw32/lib
+		PATHS
+		/sw
+		/opt/local
+		/opt/csw
+		/opt
+	)
+ENDIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+SET(SDL2_TTF_FOUND "NO")
+	IF(SDL2_TTF_LIBRARY_TEMP)
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_TTF_LIBRARY ${SDL2_TTF_LIBRARY_TEMP} CACHE STRING "Where the SDL2_ttf Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_TTF_LIBRARY_TEMP "${SDL2_TTF_LIBRARY_TEMP}" CACHE INTERNAL "")
+	SET(SDL2_TTF_FOUND "YES")
+ENDIF(SDL2_TTF_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_TTF REQUIRED_VARS SDL2_TTF_LIBRARY SDL2_TTF_INCLUDE_DIR)
+

--- a/cmake/FindZLIB.cmake
+++ b/cmake/FindZLIB.cmake
@@ -1,0 +1,48 @@
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+
+# - Try to find ZLIB
+# Once done, this will define
+#
+#  ZLIB_FOUND - system has ZLIB
+#  ZLIB_INCLUDE_DIRS - the ZLIB include directories 
+#  ZLIB_LIBRARIES - link these to use ZLIB
+
+include(FindPkgMacros)
+findpkg_begin(ZLIB)
+
+# Get path, convert backslashes as ${ENV_${var}}
+getenv_path(ZLIB_HOME)
+
+# construct search paths
+set(ZLIB_PREFIX_PATH ${ZLIB_HOME} ${ENV_ZLIB_HOME})
+create_search_paths(ZLIB)
+# redo search if prefix path changed
+clear_if_changed(ZLIB_PREFIX_PATH
+  ZLIB_LIBRARY_FWK
+  ZLIB_LIBRARY_REL
+  ZLIB_LIBRARY_DBG
+  ZLIB_INCLUDE_DIR
+)
+
+set(ZLIB_LIBRARY_NAMES z zlib zdll)
+get_debug_names(ZLIB_LIBRARY_NAMES)
+
+use_pkgconfig(ZLIB_PKGC zzip-zlib-config)
+
+findpkg_framework(ZLIB)
+
+find_path(ZLIB_INCLUDE_DIR NAMES zlib.h HINTS ${ZLIB_INC_SEARCH_PATH} ${ZLIB_PKGC_INCLUDE_DIRS})
+find_library(ZLIB_LIBRARY_REL NAMES ${ZLIB_LIBRARY_NAMES} HINTS ${ZLIB_LIB_SEARCH_PATH} ${ZLIB_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" release relwithdebinfo minsizerel)
+find_library(ZLIB_LIBRARY_DBG NAMES ${ZLIB_LIBRARY_NAMES_DBG} HINTS ${ZLIB_LIB_SEARCH_PATH} ${ZLIB_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" debug)
+
+make_library_set(ZLIB_LIBRARY)
+
+findpkg_finish(ZLIB)
+

--- a/cmake/Findassimp.cmake
+++ b/cmake/Findassimp.cmake
@@ -1,0 +1,81 @@
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(ASSIMP_ARCHITECTURE "64")
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+	set(ASSIMP_ARCHITECTURE "32")
+endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	
+if(WIN32)
+	set(ASSIMP_ROOT_DIR CACHE PATH "ASSIMP root directory")
+
+	# Find path of each library
+	find_path(ASSIMP_INCLUDE_DIR
+		NAMES
+			assimp/anim.h
+		HINTS
+			${ASSIMP_ROOT_DIR}/include
+	)
+
+	if(MSVC12)
+		set(ASSIMP_MSVC_VERSION "vc120")
+	elseif(MSVC14)	
+		set(ASSIMP_MSVC_VERSION "vc140")
+	endif(MSVC12)
+	
+	if(MSVC12 OR MSVC14)
+	
+		find_path(ASSIMP_LIBRARY_DIR
+			NAMES
+				assimp-${ASSIMP_MSVC_VERSION}-mt.lib
+			HINTS
+				${ASSIMP_ROOT_DIR}/lib${ASSIMP_ARCHITECTURE}
+		)
+		
+		find_library(ASSIMP_LIBRARY_RELEASE				assimp-${ASSIMP_MSVC_VERSION}-mt.lib 			PATHS ${ASSIMP_LIBRARY_DIR})
+		find_library(ASSIMP_LIBRARY_DEBUG				assimp-${ASSIMP_MSVC_VERSION}-mtd.lib			PATHS ${ASSIMP_LIBRARY_DIR})
+		
+		set(ASSIMP_LIBRARY 
+			optimized 	${ASSIMP_LIBRARY_RELEASE}
+			debug		${ASSIMP_LIBRARY_DEBUG}
+		)
+		
+		set(ASSIMP_LIBRARIES "ASSIMP_LIBRARY_RELEASE" "ASSIMP_LIBRARY_DEBUG")
+	
+		FUNCTION(ASSIMP_COPY_BINARIES TargetDirectory)
+			ADD_CUSTOM_TARGET(AssimpCopyBinaries
+				COMMAND ${CMAKE_COMMAND} -E copy ${ASSIMP_ROOT_DIR}/bin${ASSIMP_ARCHITECTURE}/assimp-${ASSIMP_MSVC_VERSION}-mtd.dll 	${TargetDirectory}/Debug/assimp-${ASSIMP_MSVC_VERSION}-mtd.dll
+				COMMAND ${CMAKE_COMMAND} -E copy ${ASSIMP_ROOT_DIR}/bin${ASSIMP_ARCHITECTURE}/assimp-${ASSIMP_MSVC_VERSION}-mt.dll 		${TargetDirectory}/Release/assimp-${ASSIMP_MSVC_VERSION}-mt.dll
+			COMMENT "Copying Assimp binaries to '${TargetDirectory}'"
+			VERBATIM)
+		ENDFUNCTION(ASSIMP_COPY_BINARIES)
+	
+	endif()
+	
+else(WIN32)
+
+	find_path(
+	  assimp_INCLUDE_DIRS
+	  NAMES assimp #postprocess.h scene.h version.h config.h cimport.h
+	  PATHS /usr/local/include/ /usr/include/
+	)
+
+	find_library(
+	  assimp_LIBRARIES
+	  NAMES assimp
+	  PATHS /usr/local/lib/
+	)
+
+	if (assimp_INCLUDE_DIRS AND assimp_LIBRARIES)
+	  SET(assimp_FOUND TRUE)
+	ENDIF (assimp_INCLUDE_DIRS AND assimp_LIBRARIES)
+
+	if (assimp_FOUND)
+	  if (NOT assimp_FIND_QUIETLY)
+		message(STATUS "Found asset importer library: ${assimp_LIBRARIES}")
+	  endif (NOT assimp_FIND_QUIETLY)
+	else (assimp_FOUND)
+	  if (assimp_FIND_REQUIRED)
+		message(FATAL_ERROR "Could not find asset importer library")
+	  endif (assimp_FIND_REQUIRED)
+	endif (assimp_FOUND)
+	
+endif(WIN32)

--- a/include/nav_mesh.hpp
+++ b/include/nav_mesh.hpp
@@ -129,8 +129,8 @@ namespace shooter
       const float hrange,  ///< Height Range
       float& outY, ///< Floor's Y world coordinate
       float& outDistY, ///< Vertical distance to the floor
-      bool* outWalkable = NULL, ///< True if pos's Floor projection is walkable
-      float* outBorderDistance = NULL ///< Distance between the pos's Floor projection and NavMesh border
+      bool* outWalkable = nullptr, ///< True if pos's Floor projection is walkable
+      float* outBorderDistance = nullptr ///< Distance between the pos's Floor projection and NavMesh border
     ) const;
 
   private:

--- a/src/Q3Loader.cpp
+++ b/src/Q3Loader.cpp
@@ -13,6 +13,7 @@
 #include "Q3Loader.h"
 
 #include <cstdio>
+#include <cstring>
 
 template <class taType>
 void swizzle3(taType* const t) {

--- a/src/Q3Map.cpp
+++ b/src/Q3Map.cpp
@@ -101,7 +101,7 @@ namespace
   typedef unordered_map<string, TFilePosAndLen> TArchivedFilesInfoMap;
 
   /// Read files names and positions from a zip archive
-  TArchivedFilesInfoMap ReadArchiveFileNames(unzFile zipFileHandle, TFilePosAndLen& bspFilePosAndLen = TFilePosAndLen())
+  TArchivedFilesInfoMap ReadArchiveFileNames(unzFile zipFileHandle, TFilePosAndLen& bspFilePosAndLen)
   {
     TArchivedFilesInfoMap result;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <string>
 
-#include <GL\glew.h>
+#include <GL/glew.h>
 #include <SDL.h>
 #include <SDL_opengl.h>
 #include <ctpl/ctpl_stl.h>

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -17,10 +17,16 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
-#include <filesystem> // requires at least VS2013
+
+#ifdef _WIN32
+    #include <filesystem> // requires at least VS2013
+    using namespace std::tr2::sys;
+#elif __linux__
+    #include <experimental/filesystem> // tested with gcc version 5.3.1 20160406 (Red Hat 5.3.1-6) (GCC)
+    using namespace std::experimental::filesystem;
+#endif
 
 #include <SDL_image.h>
-
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -28,13 +34,12 @@
 #include <glm/gtx/compatibility.hpp>
 
 #include <assimp/Importer.hpp>
-#include <assimp/PostProcess.h>
-#include <assimp/Scene.h>
+#include <assimp/postprocess.h>
+#include <assimp/scene.h>
 #include <assimp/matrix4x4.h>
 
 using namespace std;
 using namespace glm;
-using namespace std::tr2::sys;
 using namespace ShaderUtils;
 
 namespace shooter {

--- a/src/shader_defines.h
+++ b/src/shader_defines.h
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2016 Iulian Marinescu Ghetau giulian2003@gmail.com
+//
+// This software is provided 'as-is', without any express or implied
+// warranty.  In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely.  If you use this software in a product, an acknowledgment in the 
+// product documentation would be appreciated but is not required.
+//
+
+/// Vertex shader input parameters locations
+#define VERT_POSITION_LOC 0
+#define VERT_NORMAL_LOC 1
+#define VERT_COLOR_LOC 2
+#define VERT_DIFFUSE_TEX_COORD_LOC 3
+#define VERT_LIGHTMAP_TEX_COORD_LOC 4
+#define VERT_BONE_IDS_LOC 5
+#define VERT_BONE_WEIGHTS_LOC 6
+
+//// Fragment shader output parameters locations
+#define FRAG_COLOR_LOC 0
+
+/// Uniform Bindings Points
+#define MATRICES_BINDING 1
+#define MATERIAL_BINDING 2
+#define LIGHT_BINDING 3
+#define BONES_BINDING 4
+
+/// Uniform locations
+#define LIGHT_POSITION_LOC 0
+#define CAMERA_POSITION_LOC 1
+
+#define BILLBOARD_ORIGIN_LOC 2
+#define BILLBOARD_ROTATION_AXIS 3
+#define BILLBOARD_IN_WORLD_SPACE 4
+#define BILLBOARD_WIDTH 5
+#define BILLBOARD_HEIGHT 6
+#define CAMERA_POS_LOC 7
+#define GLOBAL_TIME_LOC 8
+
+/// Texture Units
+#define DIFFUSE_TEX_UNIT 0
+#define LIGHTMAP_TEX_UNIT 1
+
+const int MAX_BONES = 100;


### PR DESCRIPTION
Hello there!  I got the demo to compile on Linux.  Here's a pull request if you're interested in the changes, let me know what you think!  Unfortunately, I don't have Windows, so I can't test if it still works, but I hope I did not break anything :)

Change overview:
1. Adding cmake find scripts for SDL, Assimp, GLM, etc.
2. Modified top CMakeLists.txt
3. Q3Loader.cpp was complaining of missing string types -- included <cstring>
4. main.cpp was using backslash in an include which was confusing GCC
5. resources.cpp uses <filesystem>, which is still experimental for Linux, and is in a different place
6. Q3Map.cpp was using a default assignment for a reference parameter, which was failing the build.
   I am not sure if this is a valid statement in MSVC, but GCC is complaining about it not being an lvalue.
   Have not used this type of thing before, might be some compile flags could mask this problem,
   but I "fixed" it for now by not having a default assign.
    -  TArchivedFilesInfoMap ReadArchiveFileNames(unzFile zipFileHandle, TFilePosAndLen& bspFilePosAndLen = TFilePosAndLen())
    +  TArchivedFilesInfoMap ReadArchiveFileNames(unzFile zipFileHandle, TFilePosAndLen& bspFilePosAndLen)

Build is successful on Fedora 23 with gcc 5.3.1
Not tested on Windows or Mac